### PR TITLE
TypeScript 2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -685,9 +685,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "snabbdom-to-html": "^3.0.1",
     "tap-list": "^1.0.1",
     "tape": "^4.6.3",
-    "typescript": "^2.4.2"
+    "typescript": "^2.5.2"
   },
   "peerDependencies": {
     "xstream": "*"


### PR DESCRIPTION
This PR updates TypeScript to v2.5: [Announcing TypeScript 2.5](https://blogs.msdn.microsoft.com/typescript/2017/08/31/announcing-typescript-2-5/)