### PR TITLE
Update TypeScript to 2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,9 +814,9 @@
       }
     },
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tap-list": "^1.0.1",
     "tape": "^4.8.0",
     "tslint": "^5.8.0",
-    "typescript": "^2.6.1"
+    "typescript": "^2.7.1"
   },
   "peerDependencies": {
     "xstream": "*"


### PR DESCRIPTION
Closes #26

This PR updates the TypeScript development dependency to `^2.7`